### PR TITLE
Fix installation on Perl 5.20

### DIFF
--- a/inc/Devel/CheckLib.pm
+++ b/inc/Devel/CheckLib.pm
@@ -165,7 +165,7 @@ sub assert_lib {
     # work-a-like for Makefile.PL's LIBS and INC arguments
     # if given as command-line argument, append to %args
     for my $arg (@ARGV) {
-        for my $mm_attr_key qw(LIBS INC) {
+        for my $mm_attr_key (qw(LIBS INC)) {
             if (my ($mm_attr_value) = $arg =~ /\A $mm_attr_key = (.*)/x) {
             # it is tempting to put some \s* into the expression, but the
             # MM command-line parser only accepts LIBS etc. followed by =,


### PR DESCRIPTION
The paren-less qw-in-for syntax is removed
